### PR TITLE
fix: remove . from uds deploy

### DIFF
--- a/demos/mattermost/README.md
+++ b/demos/mattermost/README.md
@@ -7,7 +7,7 @@ A mattermost server you can run on your local machine, packaged up as a single a
 ```sh
 # copy the core-slim zarf package to the local directory core-slim
 uds run build-mattermost-bundle
-uds deploy . --confirm
+uds deploy --confirm
 #open a browser to https://chat.uds.dev
 ```
 

--- a/exercises/mattermost-exercise/mattermost-exercise.md
+++ b/exercises/mattermost-exercise/mattermost-exercise.md
@@ -50,6 +50,6 @@ In this example the components of this application that pull from an oci registr
 
 ```sh
 uds run build-mattermost-bundle
-uds deploy . --confirm
+uds deploy --confirm
 #open a browser to https://chat.uds.dev
 ```


### PR DESCRIPTION
removes the . from uds deploy for the mattermost example that was causing the tar file to not be found