### PR TITLE
chore: update the password to be inline with STIG guidance

### DIFF
--- a/1-tutorials/4-UDS-core-apps/authorization/tasks/demo-tasks.yaml
+++ b/1-tutorials/4-UDS-core-apps/authorization/tasks/demo-tasks.yaml
@@ -24,7 +24,7 @@ tasks:
             sleep 5
 
             # Create admin user with curl
-            PASSWORD=$(openssl rand -base64 12)
+            PASSWORD=$(openssl rand -base64 15)
             STATE_COOKIE=$(curl --silent --output /dev/null --cookie-jar - http://localhost:8080/ | grep "WELCOME_STATE_CHECKER" | awk '{print $7}')
             curl --silent --show-error http://localhost:8080/ \
               -H "Cookie: WELCOME_STATE_CHECKER=${STATE_COOKIE}" \


### PR DESCRIPTION
STIGs are usually inconsistent with this though 15 is usually the common minimum for password length - this changes this password to be in line with this recommendation.

Examples:
https://www.tenable.com/audits/items/DISA_STIG_Red_Hat_Enterprise_Linux_8_v2r3.audit:bc4a56e7e550295e0ac8fdc30f16a0c0
https://www.tenable.com/audits/items/DISA_F5_BIG-IP_Device_Management_v2r4.audit:92e35cb0001b03ff9cff1da2141c9fb2
https://www.stigqter.com/stigs/SV-222536r508029_rule.html