### PR TITLE
docs: Fix removed zarf sbom command in zarf tutorial

### DIFF
--- a/1-tutorials/1-zarf/zarf-tutorial.md
+++ b/1-tutorials/1-zarf/zarf-tutorial.md
@@ -46,10 +46,6 @@ ls -l zarf-package-*.zst
 
 ### 4. Look at the Package Software Bill Of Materials (SBOM)
 ```bash
-uds zarf package inspect zarf-package-*.zst --sbom
-# Enter OR Ctrl+c when done to exit
-
-# Instruqt alternative
 uds zarf package inspect zarf-package-*.zst --sbom-out sbom
 uds zarf tools yq sbom/podinfo/ghcr.io_stefanprodan_podinfo_*.json | more
 # Ctrl+c when done to exit

--- a/1-tutorials/1-zarf/zarf-tutorial.md
+++ b/1-tutorials/1-zarf/zarf-tutorial.md
@@ -46,8 +46,12 @@ ls -l zarf-package-*.zst
 
 ### 4. Look at the Package Software Bill Of Materials (SBOM)
 ```bash
-uds zarf package inspect zarf-package-*.zst --sbom-out sbom
-uds zarf tools yq sbom/podinfo/ghcr.io_stefanprodan_podinfo_*.json | more
+uds zarf package inspect sbom zarf-package-*.zst
+open podinfo/sbom-viewer-ghcr.io_stefanprodan_podinfo_*.html  # Or open file directly in your browser
+
+# Instruqt alternative
+uds zarf package inspect sbom zarf-package-*.zst
+uds zarf tools yq podinfo/ghcr.io_stefanprodan_podinfo_*.json | more
 # Ctrl+c when done to exit
 ```
 


### PR DESCRIPTION
Update's instructions or viewing sboms in the zarf tutorial. `uds zarf package inspect zarf-package-*.zst --sbom` is no longer a working zarf command. 