### PR TITLE
chore: update UDS Docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Items to complete before starting tutorials can be found in [prerequisite.md](ht
 ## Resources
 
 - [Workshop Repo](https://github.com/defenseunicorns/workshops)
-- [UDS Docs](https://uds.defenseunicorns.com/docs/why-usd/)
+- [UDS Docs](https://uds.defenseunicorns.com/overview/why-uds/)
 - [Zarf Docs](https://docs.zarf.dev/)
 - [UDS Core](https://github.com/defenseunicorns/uds-core)
 - [UDS Common](https://github.com/defenseunicorns/uds-common)


### PR DESCRIPTION
While going through the README, I noticed this link was pointing to an out-of-date address, so I thought it be good to update.

If there's a better page to point to now, I'm happy to adjust, I tried to match what I assumed to be the previous page as best as I could.