### PR TITLE
chore: add missing backticks to close out code blocks

### DIFF
--- a/1-tutorials/1-zarf/zarf-tutorial.md
+++ b/1-tutorials/1-zarf/zarf-tutorial.md
@@ -101,4 +101,4 @@ kubectl port-forward --address=0.0.0.0 -n podinfo svc/podinfo 9999:9898
 ```bash
 k3d cluster list
 k3d cluster delete --all
-
+```

--- a/1-tutorials/2-pepr/pepr-tutorial.md
+++ b/1-tutorials/2-pepr/pepr-tutorial.md
@@ -117,3 +117,4 @@ Open in a browser:
 ```bash
 k3d cluster list
 k3d cluster delete --all
+```


### PR DESCRIPTION
I noticed these were missing while reading through the tutorials